### PR TITLE
Massive code dump from murex

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,10 +4,26 @@
 
 ### 3.0.0
 
-Where do I start? So many changes!
+This release brings a considerable number of new features and bug fixes
+inherited from readline's use in murex (https://github.com/lmorg/murex)
 
-* wrapped lines fixed (where the input line is longer than the terminal width)
+* Wrapped lines finally working (where the input line is longer than the
+  terminal width)
 
+* Delayed tab completion - allows asynchronous updates to the tab completion so
+  slower suggestions do not halt the user experience
+
+* Delayed syntax timer - allows syntax highlighting to run asynchronously for 
+  slower parsers (eg spell checkers)
+
+* Support for GetCursorPos ANSI escape sequence (though I don't have a terminal
+  which supports this to test the code on)
+
+* Better support for wrapped hint text lines
+
+* Fixed bug with $EDITOR error handling in Windows and Plan 9
+
+* Code clean up - fewer writes to the terminal
 
 ### 2.1.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@
 
 ## Changes
 
+### 3.0.0
+
+Where do I start? So many changes!
+
+* wrapped lines fixed (where the input line is longer than the terminal width)
+
+
 ### 2.1.0
 
 Error returns from `readline` have been created as error a variable, which is
@@ -31,8 +38,3 @@ var (
 	EOF = errors.New("EOF")
 )
 ```
-
-## Version Information
-
-`readline`'s version numbers are based on Semantic Versioning. More details can
-be found in the [README.md](README.md#version-information).

--- a/README.md
+++ b/README.md
@@ -66,16 +66,16 @@ Because the last thing a developer wants is to do is fix breaking changes after
 updating modules, I will make the following guarantees:
 
 * The version string will be based on Semantic Versioning. ie version numbers
-  will be formatted `v(major).(minor).(patch)` - for example `v2.0.1`
+  will be formatted `(major).(minor).(patch)` - for example `2.0.1`
 
-* `major` releases _will_ have breaking changes. Be sure to read [CHANGES.md](CHANGES.md)
-  for upgrade instructions
+* `major` releases _will_ have breaking changes. Be sure to read CHANGES.md for
+  upgrade instructions
 
 * `minor` releases will contain new APIs or introduce new user facing features
   which may affect useability from an end user perspective. However `minor`
   releases will not break backwards compatibility at the source code level and
   nor will it break existing expected user-facing behavior. These changes will
-  be documented in [CHANGES.md](CHANGES.md) too
+  be documented in CHANGES.md too
 
 * `patch` releases will be bug fixes and such like. Where the code has changed
   but both API endpoints and user experience will remain the same (except where

--- a/cursor.go
+++ b/cursor.go
@@ -1,0 +1,159 @@
+package readline
+
+import (
+	"os"
+	"regexp"
+	"strconv"
+)
+
+func leftMost() []byte {
+	fd := int(os.Stdout.Fd())
+	w, _, err := GetSize(fd)
+	if err != nil {
+		return []byte{'\r', '\n'}
+	}
+
+	b := make([]byte, w+1)
+	for i := 0; i < w; i++ {
+		b[i] = ' '
+	}
+	b[w] = '\r'
+
+	return b
+}
+
+var rxRcvCursorPos = regexp.MustCompile("^\x1b([0-9]+);([0-9]+)R$")
+
+func (rl *Instance) getCursorPos() (x int, y int) {
+	if !rl.EnableGetCursorPos {
+		return -1, -1
+	}
+
+	disable := func() (int, int) {
+		os.Stderr.WriteString("\r\ngetCursorPos() not supported by terminal emulator, disabling....\r\n")
+		rl.EnableGetCursorPos = false
+		return -1, -1
+	}
+
+	print(seqGetCursorPos)
+	b := make([]byte, 64)
+	i, err := os.Stdin.Read(b)
+	if err != nil {
+		return disable()
+	}
+
+	if !rxRcvCursorPos.Match(b[:i]) {
+		return disable()
+	}
+
+	match := rxRcvCursorPos.FindAllStringSubmatch(string(b[:i]), 1)
+	y, err = strconv.Atoi(match[0][1])
+	if err != nil {
+		return disable()
+	}
+
+	x, err = strconv.Atoi(match[0][2])
+	if err != nil {
+		return disable()
+	}
+
+	return x, y
+}
+
+func moveCursorUp(i int) {
+	if i < 1 {
+		return
+	}
+
+	printf("\x1b[%dA", i)
+}
+
+func moveCursorDown(i int) {
+	if i < 1 {
+		return
+	}
+
+	printf("\x1b[%dB", i)
+}
+
+func moveCursorForwards(i int) {
+	if i < 1 {
+		return
+	}
+
+	printf("\x1b[%dC", i)
+}
+
+func moveCursorBackwards(i int) {
+	if i < 1 {
+		return
+	}
+
+	printf("\x1b[%dD", i)
+}
+
+func (rl *Instance) moveCursorToStart() {
+	posX, posY := lineWrapPos(rl.promptLen, rl.pos, rl.termWidth)
+
+	moveCursorBackwards(posX - rl.promptLen)
+	moveCursorUp(posY)
+}
+
+func (rl *Instance) moveCursorFromStartToLinePos() {
+	posX, posY := lineWrapPos(rl.promptLen, rl.pos, rl.termWidth)
+	moveCursorForwards(posX)
+	moveCursorDown(posY)
+}
+
+func (rl *Instance) moveCursorFromEndToLinePos() {
+	lineX, lineY := lineWrapPos(rl.promptLen, len(rl.line), rl.termWidth)
+	posX, posY := lineWrapPos(rl.promptLen, rl.pos, rl.termWidth)
+	moveCursorBackwards(lineX - posX)
+	moveCursorUp(lineY - posY)
+}
+
+// moveCursorToLinePos should only be used on extreme circumstances because it
+// causes the cursor to jump around quite a bit
+func (rl *Instance) moveCursorFromUnknownToLinePos() {
+	_, lineY := lineWrapPos(rl.promptLen, len(rl.line), rl.termWidth)
+	posX, posY := lineWrapPos(rl.promptLen, rl.pos, rl.termWidth)
+	//moveCursorBackwards(lineX)
+	print("\r")
+	moveCursorForwards(posX)
+	moveCursorUp(lineY - posY)
+}
+
+func (rl *Instance) moveCursorByAdjust(adjust int) {
+	oldX, oldY := lineWrapPos(rl.promptLen, rl.pos, rl.termWidth)
+
+	rl.pos += adjust
+
+	if rl.pos < 0 {
+		rl.pos = 0
+	}
+	if rl.pos > len(rl.line) {
+		rl.pos = len(rl.line)
+	}
+
+	if rl.modeViMode != vimInsert && rl.pos == len(rl.line) {
+		rl.pos--
+	}
+
+	newX, newY := lineWrapPos(rl.promptLen, rl.pos, rl.termWidth)
+
+	y := newY - oldY
+	switch {
+	case y < 0:
+		moveCursorUp(-y)
+	case y > 0:
+		moveCursorDown(y)
+	}
+
+	x := newX - oldX
+	switch {
+	case x < 0:
+		moveCursorBackwards(-x)
+	case x > 0:
+		moveCursorForwards(x)
+	}
+}

--- a/editor.go
+++ b/editor.go
@@ -7,44 +7,9 @@ import (
 	"encoding/hex"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"strconv"
 	"time"
 )
-
-func (rl *Instance) launchEditor(multiline []rune) ([]rune, error) {
-	name, err := rl.writeTempFile([]byte(string(multiline)))
-	if err != nil {
-		return multiline, err
-	}
-
-	editor := os.Getenv("EDITOR")
-	// default editor is $EDITOR not set
-	if editor == "" {
-		editor = "vi"
-	}
-
-	cmd := exec.Command(editor, name)
-
-	//cmd.SysProcAttr = &syscall.SysProcAttr{
-	//	Ctty: int(os.Stdout.Fd()),
-	//}
-
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	if err := cmd.Start(); err != nil {
-		return multiline, err
-	}
-
-	if err := cmd.Wait(); err != nil {
-		return multiline, err
-	}
-
-	b, err := readTempFile(name)
-	return []rune(string(b)), err
-}
 
 func (rl *Instance) writeTempFile(content []byte) (string, error) {
 	fileID := strconv.Itoa(time.Now().Nanosecond()) + ":" + string(rl.line)

--- a/editor_plan9.go
+++ b/editor_plan9.go
@@ -1,9 +1,9 @@
-// +build windows
+// +build plan9
 
 package readline
 
 import "errors"
 
 func (rl *Instance) launchEditor(multiline []rune) ([]rune, error) {
-	return rl.line, errors.New("Not currently supported on Windows")
+	return rl.line, errors.New("Not currently supported on Plan 9")
 }

--- a/editor_unix.go
+++ b/editor_unix.go
@@ -2,4 +2,39 @@
 
 package readline
 
+import (
+	"os"
+	"os/exec"
+)
+
 const defaultEditor = "vi"
+
+func (rl *Instance) launchEditor(multiline []rune) ([]rune, error) {
+	name, err := rl.writeTempFile([]byte(string(multiline)))
+	if err != nil {
+		return multiline, err
+	}
+
+	editor := os.Getenv("EDITOR")
+	// default editor if $EDITOR not set
+	if editor == "" {
+		editor = defaultEditor
+	}
+
+	cmd := exec.Command(editor, name)
+
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		return multiline, err
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return multiline, err
+	}
+
+	b, err := readTempFile(name)
+	return []rune(string(b)), err
+}

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/lmorg/readline
+
+go 3.0

--- a/godoc.go
+++ b/godoc.go
@@ -1,7 +1,2 @@
 // Package readline is a pure-Go re-imagining of the UNIX readline API
-//
-// This package is designed to be run independently from murex and at some
-// point it will be separated into it's own git repository (at a stage when I
-// am confident that murex will no longer be the primary driver for features,
-// bugs or other code changes)
 package readline

--- a/hint.go
+++ b/hint.go
@@ -9,18 +9,27 @@ func (rl *Instance) getHintText() {
 	rl.hintText = rl.HintText(rl.line, rl.pos)
 }
 
-func (rl *Instance) writeHintText() {
+func (rl *Instance) writeHintText(resetCursorPos bool) {
 	if len(rl.hintText) == 0 {
 		rl.hintY = 0
 		return
 	}
 
-	width := GetTermWidth()
+	hintText := string(rl.hintText)
+
+	if rl.modeTabCompletion && rl.tcDisplayType == TabDisplayGrid &&
+		!rl.modeTabFind && len(rl.tcSuggestions) > 0 {
+		cell := (rl.tcMaxX * (rl.tcPosY - 1)) + rl.tcOffset + rl.tcPosX - 1
+		description := rl.tcDescriptions[rl.tcSuggestions[cell]]
+		if description != "" {
+			hintText = description
+		}
+	}
 
 	// Determine how many lines hintText spans over
 	// (Currently there is no support for carridge returns / new lines)
-	hintLength := strLen(string(rl.hintText))
-	n := float64(hintLength) / float64(width)
+	hintLength := strLen(hintText)
+	n := float64(hintLength) / float64(rl.termWidth)
 	if float64(int(n)) != n {
 		n++
 	}
@@ -28,25 +37,30 @@ func (rl *Instance) writeHintText() {
 
 	if rl.hintY > 3 {
 		rl.hintY = 3
-		rl.hintText = rl.hintText[:(width*3)-4]
-		rl.hintText = append(rl.hintText, '.', '.', '.')
+		hintText = hintText[:(rl.termWidth*3)-4] + "..."
 	}
 
-	hintText := rl.hintText
+	if resetCursorPos {
+		_, lineY := lineWrapPos(rl.promptLen, len(rl.line), rl.termWidth)
+		posX, posY := lineWrapPos(rl.promptLen, rl.pos, rl.termWidth)
+		y := lineY - posY
+		moveCursorDown(y)
 
-	if rl.modeTabCompletion && rl.tcDisplayType == TabDisplayGrid &&
-		!rl.modeTabFind && len(rl.tcSuggestions) > 0 {
-		cell := (rl.tcMaxX * (rl.tcPosY - 1)) + rl.tcOffset + rl.tcPosX - 1
-		description := rl.tcDescriptions[rl.tcSuggestions[cell]]
-		if description != "" {
-			hintText = []rune(description)
-		}
+		print("\r\n" + rl.HintFormatting + hintText + seqReset)
+
+		moveCursorUp(rl.hintY + lineY - posY)
+		moveCursorBackwards(rl.termWidth)
+		moveCursorForwards(posX)
 	}
-
-	print("\r\n" + rl.HintFormatting + string(hintText) + seqReset)
 }
 
 func (rl *Instance) resetHintText() {
 	rl.hintY = 0
 	rl.hintText = []rune{}
+}
+
+// SetHintText is a nasty function for force writing a new hint text. Use sparingly!
+func (rl *Instance) SetHintText(s string) {
+	rl.hintText = []rune(s)
+	rl.writeHintText(true)
 }

--- a/instance.go
+++ b/instance.go
@@ -2,12 +2,14 @@ package readline
 
 import (
 	"os"
+	"sync"
 )
 
 // Instance is used to encapsulate the parameter group and run time of any given
 // readline instance so that you can reuse the readline API for multiple entry
 // captures without having to repeatedly unload configuration.
 type Instance struct {
+	mutex sync.Mutex
 
 	// PasswordMask is what character to hide password entry behind.
 	// Once enabled, set to 0 (zero) to disable the mask again.
@@ -32,7 +34,11 @@ type Instance struct {
 	// TabCompleter is a simple function that offers completion suggestions.
 	// It takes the readline line ([]rune) and cursor pos. Returns a prefix
 	// string, an array of suggestions and a map of definitions (optional).
-	TabCompleter func([]rune, int) (string, []string, map[string]string, TabDisplayType)
+	TabCompleter      func([]rune, int, DelayedTabContext) (string, []string, map[string]string, TabDisplayType)
+	delayedTabContext DelayedTabContext
+
+	MinTabItemLength int
+	MaxTabItemLength int
 
 	// MaxTabCompletionRows is the maximum number of rows to display in the tab
 	// completion grid.
@@ -45,8 +51,13 @@ type Instance struct {
 	// the new line and cursor position.
 	SyntaxCompleter func([]rune, int) ([]rune, int)
 
+	// DelayedSyntaxWorker allows for syntax highlighting happen to the line
+	// after the line has been drawn.
+	DelayedSyntaxWorker func([]rune) []rune
+	delayedSyntaxCount  int64
+
 	// HintText is a helper function which displays hint text the prompt.
-	// HintText takes the line input from the promt and the cursor position.
+	// HintText takes the line input from the prompt and the cursor position.
 	// It returns the hint text to display.
 	HintText func([]rune, int) []rune
 
@@ -69,6 +80,7 @@ type Instance struct {
 	promptLen     int    //= 4
 	line          []rune
 	pos           int
+	termWidth     int
 	multiline     []byte
 	multisplit    []string
 	skipStdinRead bool
@@ -110,6 +122,8 @@ type Instance struct {
 
 	// event
 	evtKeyPress map[string]func(string, []rune, int) *EventReturn
+
+	EnableGetCursorPos bool
 }
 
 // NewInstance is used to create a readline instance and initialise it with sane
@@ -128,6 +142,8 @@ func NewInstance() *Instance {
 	rl.evtKeyPress = make(map[string]func(string, []rune, int) *EventReturn)
 
 	rl.TempDirectory = os.TempDir()
+
+	//rl.EnableGetCursorPos = true
 
 	return rl
 }

--- a/raw_solaris.go
+++ b/raw_solaris.go
@@ -79,4 +79,3 @@ func GetSize(fd int) (width, height int, err error) {
 	}
 	return int(ws.Col), int(ws.Row), nil
 }
-

--- a/raw_unix.go
+++ b/raw_unix.go
@@ -74,4 +74,3 @@ func GetSize(fd int) (width, height int, err error) {
 	}
 	return int(ws.Col), int(ws.Row), nil
 }
-

--- a/raw_windows.go
+++ b/raw_windows.go
@@ -70,4 +70,3 @@ func GetSize(fd int) (width, height int, err error) {
 	}
 	return int(info.Size.X), int(info.Size.Y), nil
 }
-

--- a/syntax.go
+++ b/syntax.go
@@ -13,8 +13,5 @@ func (rl *Instance) syntaxCompletion() {
 	newPos++
 
 	rl.line = newLine
-	rl.echo()
-	moveCursorForwards(newPos - rl.pos - 1)
-	moveCursorBackwards(rl.pos - newPos + 1)
 	rl.pos = newPos
 }

--- a/tabfind.go
+++ b/tabfind.go
@@ -11,7 +11,7 @@ func (rl *Instance) backspaceTabFind() {
 
 func (rl *Instance) updateTabFind(r []rune) {
 	rl.tfLine = append(rl.tfLine, r...)
-	rl.hintText = append([]rune("regexp find: "), rl.tfLine...)
+	rl.hintText = append([]rune("regex find: "), rl.tfLine...)
 
 	defer func() {
 		rl.clearHelpers()
@@ -48,7 +48,7 @@ func (rl *Instance) resetTabFind() {
 	if rl.modeAutoFind {
 		rl.hintText = []rune{}
 	} else {
-		rl.hintText = []rune("Cancelled regexp suggestion find.")
+		rl.hintText = []rune("Cancelled regex suggestion find.")
 	}
 
 	rl.clearHelpers()

--- a/tabgrid_test.go
+++ b/tabgrid_test.go
@@ -1,0 +1,29 @@
+package readline
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCropCaption(t *testing.T) {
+	// We aren't really bothered about the quality of the output here, just
+	// testing that the function doesn't generate any slice out of bounds
+	// exceptions
+
+	var caption, maxLen, cellWidth int
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Panic raised on iteration %d,%d,%d: %s", caption, maxLen, cellWidth, r)
+		}
+	}()
+
+	for caption = 0; caption < 101; caption++ {
+		for maxLen = 0; maxLen < 101; maxLen++ {
+			for cellWidth = 0; cellWidth < 101; cellWidth++ {
+				cropCaption(strings.Repeat("s", caption), maxLen, cellWidth)
+			}
+		}
+	}
+
+}

--- a/tabmap.go
+++ b/tabmap.go
@@ -5,8 +5,6 @@ import (
 )
 
 func (rl *Instance) initTabMap() {
-	//width := GetTermWidth()
-
 	var suggestions []string
 	if rl.modeTabFind {
 		suggestions = rl.tfSuggestions
@@ -85,23 +83,24 @@ func (rl *Instance) writeTabMap() {
 		suggestions = rl.tcSuggestions
 	}
 
-	termWidth := GetTermWidth()
-	if termWidth < 10 {
+	if rl.termWidth < 10 {
 		// terminal too small. Probably better we do nothing instead of crash
 		return
 	}
 
 	maxLength := rl.tcMaxLength
-	if maxLength > termWidth-9 {
-		maxLength = termWidth - 9
+	if maxLength > rl.termWidth-9 {
+		maxLength = rl.termWidth - 9
 	}
-	maxDescWidth := termWidth - maxLength - 4
+	maxDescWidth := rl.termWidth - maxLength - 4
 
 	cellWidth := strconv.Itoa(maxLength)
 	itemWidth := strconv.Itoa(maxDescWidth)
 
 	y := 0
-	print(seqClearScreenBelow)
+
+	//print("\r" + strings.Repeat("\n", rl.hintY) + seqClearScreenBelow)
+	moveCursorUp(1) // bit of a kludge. Really should find where the code is "\n"ing
 
 	highlight := func(y int) string {
 		if y == rl.tcPosY {

--- a/term.go
+++ b/term.go
@@ -1,10 +1,7 @@
 package readline
 
 import (
-	"fmt"
 	"os"
-	"regexp"
-	"unicode/utf8"
 )
 
 // GetTermWidth returns the width of Stdout or 80 if the width cannot be established
@@ -13,32 +10,8 @@ func GetTermWidth() (termWidth int) {
 	fd := int(os.Stdout.Fd())
 	termWidth, _, err = GetSize(fd)
 	if err != nil {
-		termWidth = 80
+		termWidth = 80 // default to 80 with term width unknown as that is the de factor standard on older terms.
 	}
 
 	return
-}
-
-func printf(format string, a ...interface{}) {
-	s := fmt.Sprintf(format, a...)
-	print(s)
-}
-
-func print(s string) {
-	os.Stdout.WriteString(s)
-}
-
-/*func rLen(r []rune) (length int) {
-	for _, i := range r {
-		length += utf8.RuneLen(i)
-	}
-	return
-}*/
-
-var rxAnsiSgr = regexp.MustCompile("\x1b\\[[:;0-9]+m")
-
-// Gets the number of runes in a string and
-func strLen(s string) int {
-	s = rxAnsiSgr.ReplaceAllString(s, "")
-	return utf8.RuneCountInString(s)
 }

--- a/timer.go
+++ b/timer.go
@@ -1,0 +1,83 @@
+package readline
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+func delayedSyntaxTimer(rl *Instance, i int64) {
+	if rl.PasswordMask != 0 || rl.DelayedSyntaxWorker == nil {
+		return
+	}
+
+	if len(rl.line)+rl.promptLen > rl.termWidth {
+		// line wraps, which is hard to do with random ANSI escape sequences
+		// so better we don't bother trying.
+		return
+	}
+
+	newLine := rl.DelayedSyntaxWorker(rl.line)
+	var sLine string
+
+	count := atomic.LoadInt64(&rl.delayedSyntaxCount)
+	if count != i {
+		return
+	}
+
+	if rl.SyntaxHighlighter != nil {
+		sLine = rl.SyntaxHighlighter(newLine)
+	} else {
+		sLine = string(newLine)
+	}
+
+	rl.moveCursorToStart()
+	print(sLine)
+	rl.moveCursorFromEndToLinePos()
+}
+
+// DelayedTabContext is a custom context interface for async updates to the tab completions
+type DelayedTabContext struct {
+	rl      *Instance
+	Context context.Context
+	cancel  context.CancelFunc
+}
+
+// AppendSuggestions updates the tab completions with additional suggestions asynchronously
+func (dtc DelayedTabContext) AppendSuggestions(suggestions []string) {
+	dtc.rl.mutex.Lock()
+	defer dtc.rl.mutex.Unlock()
+
+	for i := range suggestions {
+		select {
+		case <-dtc.Context.Done():
+			return
+
+		default:
+			dtc.rl.tcDescriptions[suggestions[i]] = dtc.rl.tcPrefix + suggestions[i]
+			dtc.rl.tcSuggestions = append(dtc.rl.tcSuggestions, suggestions[i])
+		}
+	}
+
+	dtc.rl.clearHelpers()
+	dtc.rl.renderHelpers()
+}
+
+// AppendDescriptions updates the tab completions with additional suggestions + descriptions asynchronously
+func (dtc DelayedTabContext) AppendDescriptions(suggestions map[string]string) {
+	dtc.rl.mutex.Lock()
+	defer dtc.rl.mutex.Unlock()
+
+	for k := range suggestions {
+		select {
+		case <-dtc.Context.Done():
+			return
+
+		default:
+			dtc.rl.tcDescriptions[k] = suggestions[k]
+			dtc.rl.tcSuggestions = append(dtc.rl.tcSuggestions, k)
+		}
+	}
+
+	dtc.rl.clearHelpers()
+	dtc.rl.renderHelpers()
+}

--- a/update.go
+++ b/update.go
@@ -1,64 +1,8 @@
 package readline
 
-import (
-	"strings"
-)
-
-func moveCursorUp(i int) {
-	if i < 1 {
-		return
-	}
-
-	printf("\x1b[%dA", i)
-}
-
-func moveCursorDown(i int) {
-	if i < 1 {
-		return
-	}
-
-	printf("\x1b[%dB", i)
-}
-
-func moveCursorForwards(i int) {
-	if i < 1 {
-		return
-	}
-
-	printf("\x1b[%dC", i)
-}
-
-func moveCursorBackwards(i int) {
-	if i < 1 {
-		return
-	}
-
-	printf("\x1b[%dD", i)
-}
-
-func moveCursorToLinePos(rl *Instance) {
-	moveCursorForwards(rl.promptLen + rl.pos)
-}
-
-func (rl *Instance) moveCursorByAdjust(adjust int) {
-	switch {
-	case adjust > 0:
-		moveCursorForwards(adjust)
-		rl.pos += adjust
-	case adjust < 0:
-		moveCursorBackwards(adjust * -1)
-		rl.pos += adjust
-	}
-
-	if rl.modeViMode != vimInsert && rl.pos == len(rl.line) {
-		moveCursorBackwards(1)
-		rl.pos--
-	}
-}
-
 func (rl *Instance) insert(r []rune) {
 	for {
-		// I don't really understand why `0` is creaping in at the end of the
+		// I don't really understand why `0` is creeping in at the end of the
 		// array but it only happens with unicode characters.
 		if len(r) > 1 && r[len(r)-1] == 0 {
 			r = r[:len(r)-1]
@@ -79,10 +23,8 @@ func (rl *Instance) insert(r []rune) {
 		rl.line = append(rl.line, r...)
 	}
 
+	rl.moveCursorByAdjust(len(r))
 	rl.echo()
-
-	rl.pos += len(r)
-	moveCursorForwards(len(r) - 1)
 
 	if rl.modeViMode == vimInsert {
 		rl.updateHelpers()
@@ -106,80 +48,18 @@ func (rl *Instance) delete() {
 	case rl.pos == 0:
 		rl.line = rl.line[1:]
 		rl.echo()
-		moveCursorBackwards(1)
+		//moveCursorBackwards(1)
 	case rl.pos > len(rl.line):
 		rl.backspace()
 	case rl.pos == len(rl.line):
 		rl.line = rl.line[:rl.pos]
 		rl.echo()
-		moveCursorBackwards(1)
+		//moveCursorBackwards(1)
 	default:
 		rl.line = append(rl.line[:rl.pos], rl.line[rl.pos+1:]...)
 		rl.echo()
-		moveCursorBackwards(1)
+		//moveCursorBackwards(1)
 	}
 
 	rl.updateHelpers()
-}
-
-func (rl *Instance) echo() {
-	moveCursorBackwards(rl.pos)
-
-	switch {
-	case rl.PasswordMask > 0:
-		print(strings.Repeat(string(rl.PasswordMask), len(rl.line)) + " ")
-
-	case rl.SyntaxHighlighter == nil:
-		print(string(rl.line) + " ")
-
-	default:
-		print(rl.SyntaxHighlighter(rl.line) + " ")
-	}
-
-	moveCursorBackwards(len(rl.line) - rl.pos)
-}
-
-func (rl *Instance) clearLine() {
-	if len(rl.line) == 0 {
-		return
-	}
-
-	moveCursorBackwards(rl.pos)
-	print(strings.Repeat(" ", len(rl.line)))
-	moveCursorBackwards(len(rl.line))
-
-	rl.line = []rune{}
-	rl.pos = 0
-}
-
-func (rl *Instance) resetHelpers() {
-	rl.modeAutoFind = false
-	rl.clearHelpers()
-	rl.resetHintText()
-	rl.resetTabCompletion()
-}
-
-func (rl *Instance) clearHelpers() {
-	print("\r\n" + seqClearScreenBelow)
-	moveCursorUp(1)
-	moveCursorToLinePos(rl)
-}
-
-func (rl *Instance) renderHelpers() {
-	rl.writeHintText()
-	rl.writeTabCompletion()
-
-	moveCursorUp(rl.hintY + rl.tcUsedY)
-	moveCursorBackwards(GetTermWidth())
-	moveCursorToLinePos(rl)
-}
-
-func (rl *Instance) updateHelpers() {
-	rl.tcOffset = 0
-	rl.getHintText()
-	if rl.modeTabCompletion {
-		rl.getTabCompletion()
-	}
-	rl.clearHelpers()
-	rl.renderHelpers()
 }

--- a/write.go
+++ b/write.go
@@ -1,0 +1,165 @@
+package readline
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+func printf(format string, a ...interface{}) {
+	s := fmt.Sprintf(format, a...)
+	print(s)
+}
+
+func print(s string) {
+	os.Stdout.WriteString(s)
+}
+
+var rxAnsiSgr = regexp.MustCompile("\x1b\\[[:;0-9]+m")
+
+// Gets the number of runes in a string and
+func strLen(s string) int {
+	s = rxAnsiSgr.ReplaceAllString(s, "")
+	return utf8.RuneCountInString(s)
+}
+
+func (rl *Instance) echo() {
+	if len(rl.multisplit) == 0 {
+		rl.syntaxCompletion()
+	}
+
+	lineX, lineY := lineWrapPos(rl.promptLen, len(rl.line), rl.termWidth)
+	posX, posY := lineWrapPos(rl.promptLen, rl.pos, rl.termWidth)
+
+	moveCursorBackwards(posX)
+	moveCursorUp(posY)
+	if rl.promptLen < rl.termWidth {
+		print(rl.prompt)
+	}
+
+	switch {
+	case rl.PasswordMask != 0:
+		print(strings.Repeat(string(rl.PasswordMask), len(rl.line)) + " \r\n")
+
+	case len(rl.line)+rl.promptLen > rl.termWidth:
+		fallthrough
+
+	case rl.SyntaxHighlighter == nil:
+		wrap := lineWrap(rl, rl.termWidth)
+		for i := range wrap {
+			print(wrap[i] + "\r\n")
+		}
+
+	default:
+		print(rl.SyntaxHighlighter(rl.line) + " \r\n")
+	}
+
+	moveCursorUp(lineY + 1)
+	moveCursorDown(posY)
+	moveCursorBackwards(lineX - posX + 1)
+}
+
+func lineWrap(rl *Instance, termWidth int) []string {
+	var promptLen int
+	if rl.promptLen < termWidth {
+		promptLen = rl.promptLen
+	}
+
+	n := float64(len(rl.line)+1) / (float64(termWidth) - float64(promptLen))
+	if n < 0 {
+		return []string{" "}
+	}
+
+	var (
+		ceil = int(math.Ceil(n))
+		wrap = make([]string, ceil)
+		l    = termWidth - promptLen
+		line = string(rl.line) + " "
+	)
+
+	for i := 0; i < ceil; i++ {
+		if i > 0 {
+			wrap[i] = strings.Repeat(" ", promptLen)
+		}
+		if i == ceil-1 {
+			wrap[i] += line[l*i:]
+			break
+		}
+		wrap[i] += line[l*i : l*(i+1)]
+	}
+
+	return wrap
+}
+
+func lineWrapPos(promptLen, lineLength, termWidth int) (x, y int) {
+	if promptLen >= termWidth {
+		promptLen = 0
+	}
+
+	y = lineLength / (termWidth - promptLen)
+	if y < 0 {
+		return 0, 0
+	}
+
+	l := termWidth - promptLen
+	x = lineLength - (l * y)
+	x += promptLen
+
+	return
+}
+
+func (rl *Instance) clearLine() {
+	if len(rl.line) == 0 {
+		return
+	}
+
+	rl.moveCursorToStart()
+
+	if rl.termWidth > rl.promptLen {
+		print(strings.Repeat(" ", rl.termWidth-rl.promptLen))
+	}
+	print(seqClearScreenBelow)
+
+	moveCursorBackwards(rl.termWidth)
+	print(rl.prompt)
+
+	rl.line = []rune{}
+	rl.pos = 0
+}
+
+func (rl *Instance) resetHelpers() {
+	rl.modeAutoFind = false
+	rl.clearHelpers()
+	rl.resetHintText()
+	rl.resetTabCompletion()
+}
+
+func (rl *Instance) clearHelpers() {
+	posX, posY := lineWrapPos(rl.promptLen, rl.pos, rl.termWidth)
+	_, lineY := lineWrapPos(rl.promptLen, len(rl.line), rl.termWidth)
+	y := lineY - posY
+
+	moveCursorDown(y)
+	print("\r\n" + seqClearScreenBelow)
+
+	moveCursorUp(y + 1)
+	moveCursorForwards(posX)
+}
+
+func (rl *Instance) renderHelpers() {
+	rl.writeHintText(true)
+	rl.writeTabCompletion(true)
+}
+
+func (rl *Instance) updateHelpers() {
+	rl.tcOffset = 0
+	rl.getHintText()
+	if rl.modeTabCompletion {
+		rl.getTabCompletion()
+	}
+	rl.clearHelpers()
+	rl.renderHelpers()
+}

--- a/write_test.go
+++ b/write_test.go
@@ -1,0 +1,236 @@
+package readline
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestLineWrap(t *testing.T) {
+	type TestLineWrapT struct {
+		Prompt    string
+		Line      string
+		TermWidth int
+		Expected  []string
+	}
+
+	tests := []TestLineWrapT{
+		{
+			Prompt:    "foobar",
+			Line:      "1234567890",
+			TermWidth: 80,
+			Expected:  []string{"1234567890 "},
+		},
+		{
+			Prompt:    "foobar",
+			Line:      "12345678901234567890123456789012345678901234567890123456789012345678901234567890",
+			TermWidth: 86,
+			Expected:  []string{"12345678901234567890123456789012345678901234567890123456789012345678901234567890", "       "},
+		},
+		{
+			Prompt:    "foobar",
+			Line:      "12345678901234567890123456789012345678901234567890123456789012345678901234567890",
+			TermWidth: 87,
+			Expected:  []string{"12345678901234567890123456789012345678901234567890123456789012345678901234567890 "},
+		},
+		{
+			Prompt:    "foobar",
+			Line:      "123456789012345678901234567890",
+			TermWidth: 20,
+			Expected:  []string{"12345678901234", "      56789012345678", "      90 "},
+		},
+		{
+			Prompt:    "foobar",
+			Line:      "1234567890",
+			TermWidth: 4,
+			Expected:  []string{"1234", "5678", "90 "},
+		},
+		{
+			Prompt:    "foobar",
+			Line:      "1234567890",
+			TermWidth: 5,
+			Expected:  []string{"12345", "67890", " "},
+		},
+		{
+			Prompt:    "foobar",
+			Line:      "1234567890",
+			TermWidth: 6,
+			Expected:  []string{"123456", "7890 "},
+		},
+		{
+			Prompt:    "foobar",
+			Line:      "1234567890",
+			TermWidth: 7,
+			Expected:  []string{"1", "      2", "      3", "      4", "      5", "      6", "      7", "      8", "      9", "      0", "       "},
+		},
+		{
+			Prompt:    "foobar",
+			Line:      "1234567890",
+			TermWidth: 8,
+			Expected:  []string{"12", "      34", "      56", "      78", "      90", "       "},
+		},
+	}
+
+	for i, test := range tests {
+		rl := NewInstance()
+		rl.SetPrompt(test.Prompt)
+		//rl.lineBuf = test.Line
+		rl.line = []rune(test.Line)
+
+		wrap := lineWrap(rl, test.TermWidth)
+		if len(wrap) != len(test.Expected) {
+			t.Error("Slice lens do not match:")
+			t.Logf("  Test:      %d (%s)", i, t.Name())
+			t.Logf("  Prompt:   '%s'", test.Prompt)
+			t.Logf("  Line:     '%s'", test.Line)
+			t.Logf("  Width:     %d", test.TermWidth)
+			t.Logf("  len(exp):  %d", len(test.Expected))
+			t.Logf("  len(act):  %d", len(wrap))
+			t.Logf("  Slice e:  '%s'", fmt.Sprint(test.Expected))
+			t.Logf("  Slice a:  '%s'", fmt.Sprint(wrap))
+			t.Logf("  rl.promptLen: %d'", rl.promptLen)
+			t.Logf("  rl.line:     '%s'", string(rl.line))
+			t.Logf("  rl.lineBuf:  '%s'", rl.lineBuf)
+			t.Logf("  n:            %.10f'", float64(len(rl.line))/(float64(test.TermWidth)-float64(rl.promptLen)))
+		}
+
+		for j := range wrap {
+			if wrap[j] != test.Expected[j] {
+				t.Error("Slice element does not match:")
+				t.Logf("  Test:      %d (%s)", i, t.Name())
+				t.Logf("  Prompt:   '%s'", test.Prompt)
+				t.Logf("  Line:     '%s'", test.Line)
+				t.Logf("  Width:     %d", test.TermWidth)
+				t.Logf("  Expected:  %s", test.Expected[j])
+				t.Logf("  Actual:    %s", wrap[j])
+				t.Logf("  len(exp):  %d", len(test.Expected))
+				t.Logf("  len(act):  %d", len(wrap))
+				t.Logf("  Slice e:  '%s'", fmt.Sprint(test.Expected))
+				t.Logf("  Slice a:  '%s'", fmt.Sprint(wrap))
+			}
+		}
+	}
+}
+
+func TestLineWrapPos(t *testing.T) {
+	type ExpectedT struct {
+		X, Y int
+	}
+
+	type TestLineWrapPosT struct {
+		Prompt    string
+		Line      string
+		TermWidth int
+		Expected  ExpectedT
+	}
+
+	tests := []TestLineWrapPosT{
+		{
+			Prompt:    "12345",
+			Line:      "123",
+			TermWidth: 10,
+			Expected:  ExpectedT{5 + 3, 0},
+		},
+		{
+			Prompt:    "12345",
+			Line:      "1234",
+			TermWidth: 10,
+			Expected:  ExpectedT{5 + 4, 0},
+		},
+		{
+			Prompt:    "12345",
+			Line:      "12345",
+			TermWidth: 10,
+			Expected:  ExpectedT{5 + 0, 1},
+		},
+		{
+			Prompt:    "12345",
+			Line:      "123456",
+			TermWidth: 10,
+			Expected:  ExpectedT{5 + 1, 1},
+		},
+		{
+			Prompt:    "foobar",
+			Line:      "1234567890",
+			TermWidth: 80,
+			Expected:  ExpectedT{6 + 10, 0},
+		},
+		{
+			Prompt:    "foobar",
+			Line:      "12345678901234567890123456789012345678901234567890123456789012345678901234567890",
+			TermWidth: 85,
+			Expected:  ExpectedT{6 + 1, 1},
+		},
+		{
+			Prompt:    "foobar",
+			Line:      "12345678901234567890123456789012345678901234567890123456789012345678901234567890",
+			TermWidth: 86,
+			Expected:  ExpectedT{6 + 0, 1},
+		},
+		{
+			Prompt:    "foobar",
+			Line:      "12345678901234567890123456789012345678901234567890123456789012345678901234567890",
+			TermWidth: 87,
+			Expected:  ExpectedT{6 + 80, 0},
+		},
+		{
+			Prompt:    "foobar",
+			Line:      "123456789012345678901234567890",
+			TermWidth: 20,
+			//Expected:  []string{"12345678901234", "56789012345678", "90"},
+			Expected: ExpectedT{6 + 2, 2},
+		},
+		{
+			Prompt:    "foobar",
+			Line:      "1234567890",
+			TermWidth: 4,
+			//Expected:  []string{"1234", "5678", "90"},
+			Expected: ExpectedT{0 + 2, 2},
+		},
+		{
+			Prompt:    "foobar",
+			Line:      "1234567890",
+			TermWidth: 5,
+			//Expected:  []string{"12345", "67890"},
+			Expected: ExpectedT{0 + 0, 2},
+		},
+		{
+			Prompt:    "foobar",
+			Line:      "1234567890",
+			TermWidth: 6,
+			//Expected:  []string{"123456", "7890"},
+			Expected: ExpectedT{0 + 4, 1},
+		},
+		{
+			Prompt:    "foobar",
+			Line:      "1234567890",
+			TermWidth: 7,
+			//Expected:  []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "0"},
+			Expected: ExpectedT{6 + 0, 10},
+		},
+		{
+			Prompt:    "foobar",
+			Line:      "1234567890",
+			TermWidth: 8,
+			//Expected:  []string{"12", "34", "56", "78", "90"},
+			Expected: ExpectedT{6 + 0, 5},
+		},
+	}
+
+	for i, test := range tests {
+
+		x, y := lineWrapPos(len(test.Prompt), len(test.Line), test.TermWidth)
+
+		if (test.Expected.X != x) || (test.Expected.Y != y) {
+			t.Error("X or Y does not matxh:")
+			t.Logf("  Test:      %d (%s)", i, t.Name())
+			t.Logf("  Prompt:   '%s'", test.Prompt)
+			t.Logf("  Line:     '%s'", test.Line)
+			t.Logf("  Width:     %d", test.TermWidth)
+			t.Logf("  Expected X:%d", test.Expected.X)
+			t.Logf("  Actual   X:%d", x)
+			t.Logf("  Expected Y:%d", test.Expected.Y)
+			t.Logf("  Actual   Y:%d", y)
+		}
+
+	}
+}


### PR DESCRIPTION
This release brings a considerable number of new features and bug fixes
inherited from readline's use in murex (https://github.com/lmorg/murex)

* Wrapped lines finally working (where the input line is longer than the
  terminal width)

* Delayed tab completion - allows asynchronous updates to the tab completion so
  slower suggestions do not halt the user experience

* Delayed syntax timer - allows syntax highlighting to run asynchronously for 
  slower parsers (eg spell checkers)

* Support for GetCursorPos ANSI escape sequence (though I don't have a terminal
  which supports this to test the code on)

* Better support for wrapped hint text lines

* Fixed bug with $EDITOR error handling in Windows and Plan 9

* Code clean up - fewer writes to the terminal