### PR TITLE
fix(strLen): strip all zero-width ANSI escapes, not just SGR

### DIFF
--- a/strlen_test.go
+++ b/strlen_test.go
@@ -1,0 +1,75 @@
+package readline
+
+import "testing"
+
+// TestStrLenStripsAnsi covers every escape family strLen needs to ignore
+// when computing on-screen width. Each case carries a short description
+// explaining what the input represents in the wild.
+func TestStrLenStripsAnsi(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want int
+	}{
+		// Baselines: bytes that should be counted as-is.
+		{"plain ascii", "hello", 5},
+		{"empty", "", 0},
+		{"unicode powerline glyph", "\ue0b0", 1},
+
+		// SGR (colors) — what strLen handled before this fix.
+		{"sgr reset", "\x1b[0mhi", 2},
+		{"sgr 24-bit fg", "\x1b[38;2;255;71;156mword", 4},
+		{"sgr 24-bit fg+bg", "\x1b[48;2;0;0;0m\x1b[38;2;255;255;255mok\x1b[0m", 2},
+
+		// OSC 8 hyperlinks (oh-my-posh emits these around clickable
+		// folder/git segments). Visible content here is " src ".
+		{
+			name: "osc 8 hyperlink ST terminator",
+			in:   "\x1b]8;;https://example.com\x1b\\ src \x1b]8;;\x1b\\",
+			want: 5,
+		},
+		{
+			name: "osc 8 hyperlink BEL terminator",
+			in:   "\x1b]8;;https://example.com\x07 src \x1b]8;;\x07",
+			want: 5,
+		},
+
+		// OSC 0/2 window title — emitted by omp's ConsoleTitleTemplate.
+		{"osc 0 title", "\x1b]0;murex in oh-my-posh\x07prompt", 6},
+
+		// OSC 7 CWD report — emitted by many shells/prompts for terminal
+		// "new tab in same dir" integrations.
+		{"osc 7 cwd", "\x1b]7;file:///home/u\x1b\\prompt", 6},
+
+		// OSC 1337 (iTerm proprietary) — CurrentDir / RemoteHost markers.
+		{"osc 1337 iterm", "\x1b]1337;CurrentDir=/tmp\x07$ ", 2},
+
+		// DEC private cursor save/restore — used by some transient
+		// prompts to redraw without scrolling.
+		{"dec save+restore", "\x1b7$ \x1b8", 2},
+
+		// Cursor positioning CSI sequences other than SGR — should also
+		// occupy zero visible cells.
+		{"csi cursor up", "\x1b[2A>", 1},
+		{"csi clear line", "\x1b[2K> ", 2},
+
+		// Realistic compound: SGR color + OSC 8 hyperlink + glyph + text.
+		// Visible content: " repo  main"
+		{
+			name: "compound omp-style segment",
+			in:   "\x1b[38;2;195;134;241m\x1b[48;2;255;71;156m" +
+				"\x1b]8;;https://github.com/user/repo\x1b\\ repo \x1b]8;;\x1b\\" +
+				"\x1b[0m\ue0b0\x1b[38;2;255;251;56m  main",
+			want: 13,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := strLen(tt.in)
+			if got != tt.want {
+				t.Errorf("strLen(%q) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/write.go
+++ b/write.go
@@ -29,11 +29,43 @@ func (rl *Instance) printErr(s string) {
 	_printErr(s)
 }
 
-var rxAnsiSgr = regexp.MustCompile(`\x1b\[[:;0-9]+m`)
+// rxAnsiEscape matches ANSI escape sequences that occupy zero visible
+// columns on screen. Stripping these before measuring is required for
+// any prompt or hint that uses richer output than plain SGR colors.
+//
+// Alternatives, in order:
+//
+//  1. OSC (Operating System Command): ESC ] ... (BEL | ESC \)
+//     Hyperlinks (OSC 8), window titles (OSC 0/1/2), CWD reporting
+//     (OSC 7), iTerm shell-integration marks (OSC 1337), notifications
+//     (OSC 9), etc. Both string terminators (0x07 BEL and ESC \) are
+//     accepted; the payload may not contain ESC or BEL.
+//
+//  2. CSI (Control Sequence Introducer): ESC [ params intermediates final
+//     Covers SGR (final byte 'm'), cursor moves, clears, scroll regions
+//     and friends. ECMA-48 conformant byte ranges: params 0x30-0x3F,
+//     intermediates 0x20-0x2F, final 0x40-0x7E.
+//
+//  3. Single-byte Fe escapes: ESC X where X is 0x40-0x5F
+//     Picks up DEC save/restore cursor (ESC 7 / ESC 8 are 0x37/0x38 so
+//     handled separately below), index (ESC D), next line (ESC E),
+//     reverse index (ESC M), single shifts, etc. Excludes the CSI ([)
+//     and OSC (]) introducers, which are consumed by the earlier
+//     alternatives via leftmost-first matching.
+//
+//  4. DEC private cursor save/restore: ESC 7, ESC 8
+//     Numeric finals fall outside the Fe range above.
+var rxAnsiEscape = regexp.MustCompile(
+	`\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)` +
+		`|\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]` +
+		`|\x1b[\x40-\x5f]` +
+		`|\x1b[78]`,
+)
 
-// Gets the number of runes in a string and
+// strLen returns the number of terminal cells a string would occupy on a
+// monospace display, after stripping zero-width ANSI escape sequences.
 func strLen(s string) int {
-	s = rxAnsiSgr.ReplaceAllString(s, "")
+	s = rxAnsiEscape.ReplaceAllString(s, "")
 	return runewidth.StringWidth(s)
 }
 


### PR DESCRIPTION
## Summary

`strLen()` currently strips only CSI SGR escapes (`\x1b\[[:;0-9]+m`) before
handing a string to `runewidth.StringWidth`. Any other zero-width escape
family — OSC hyperlinks, OSC titles, OSC CWD-reports, DEC save/restore, non-SGR
CSI — is counted as visible width, so the cursor offset is computed too far
to the right after the prompt is drawn.

In an interactive session this surfaces as ghost characters / cursor drift on
every keystroke. Any prompt generator that emits modern terminal escapes
(oh-my-posh, recent starship, fish-style abbreviated paths, etc.) trips it.

## Repro

Build a tiny program with `readline.Readline()`, set a prompt containing an
OSC 8 hyperlink or an OSC 0 title — e.g.

```go
rl.SetPrompt("\x1b]8;;https://example.com\x1b\\ test \x1b]8;;\x1b\\$ ")
```

— and type. The cursor and any redraws are misplaced by the URL's character
count.

## Fix

Extend the regex into a small alternation that covers every escape family
that occupies zero terminal cells:

| Family | Pattern | Examples in the wild |
|---|---|---|
| OSC (BEL or ST terminator) | `\x1b\][^\x07\x1b]*(?:\x07\|\x1b\\)` | OSC 8 hyperlinks, OSC 0/1/2 titles, OSC 7 CWD, OSC 9/1337 |
| CSI (ECMA-48 conformant) | `\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]` | SGR (existing), cursor moves, clears |
| Single-byte Fe escapes | `\x1b[\x40-\x5f]` | `ESC D`, `ESC E`, `ESC M`, single shifts |
| DEC save / restore | `\x1b[78]` | Numeric finals outside the Fe range |

Leftmost-first matching means the OSC and CSI alternatives consume their
introducers before the catch-all Fe rule can match them as 2-byte escapes.

- `strLen(s string) int` signature unchanged — no breaking change for callers.
- Internal var renamed `rxAnsiSgr → rxAnsiEscape` since it's no longer SGR-only.

## Tests

New `strlen_test.go` with 15 cases:

- ASCII baseline + empty string + single-wide Unicode glyph
- Existing SGR coverage (reset, 24-bit fg, 24-bit fg+bg)
- OSC 8 hyperlink, both terminator variants
- OSC 0 title, OSC 7 CWD, OSC 1337 iTerm proprietary
- DEC save+restore, non-SGR CSI (cursor up, clear line)
- Realistic compound: SGR + OSC 8 + powerline glyph + SGR + text

`go test ./...` passes cleanly; existing `TestLineWrap` etc. unaffected.

## What this unblocks

- **oh-my-posh on murex** — currently has to suppress every OSC-class
  emission in its murex shell-format profile because of this miscount.
  With the fix, murex can have feature parity (clickable hyperlinks,
  window titles, terminal CWD integration) with the bash/zsh/pwsh paths.
- **starship's murex plugin** — currently splits starship's two-line
  output and discards line 1 (the hint line) specifically to dodge OSC
  width miscount. Can collapse to a one-liner once the floor is fixed.
- Any future readline consumer that wants to ship a modern prompt.

## Backward compatibility

`strLen` signature unchanged, return semantics unchanged for SGR-only
inputs (existing behavior is a strict subset of the new behavior).
Callers in `readline.go` and `hint.go` need no modification.
